### PR TITLE
Pass response to callback function

### DIFF
--- a/lib/transport.js
+++ b/lib/transport.js
@@ -53,8 +53,8 @@ _.mixin(Transport.prototype, {
       pendingRequestsCount++;
       pendingRequests[fingerprint] =
         // this._send(o).done(done).fail(fail).always(always);
-        this._send(o).then(function() {
-          done();
+        this._send(o).then(function(resp) {
+          done(resp);
           always();
         }, function() {
           fail();


### PR DESCRIPTION
Otherwise Bloodhound receives null response and `async` callback never been called
